### PR TITLE
Add `ignore_includes` and `system_includes` options

### DIFF
--- a/pkg_config.bzl
+++ b/pkg_config.bzl
@@ -100,6 +100,8 @@ def _ignore_opts(opts, ignore_opts):
 
 def _symlinks(ctx, basename, srcpaths):
     ignore_includes = ctx.attr.ignore_includes
+    system_includes = ctx.attr.system_includes
+
     result = []
     root = ctx.path("")
     base = root.get_child(basename)
@@ -112,6 +114,17 @@ def _symlinks(ctx, basename, srcpaths):
         dest = "{}_{}".format(base.get_child(src.basename), idx)
         ctx.symlink(src.realpath, dest)
         result += [str(dest)[rootlen:]]
+
+    for idx, key in enumerate(system_includes):
+        src = ctx.path(key)
+        if not src.exists:
+            continue
+        dest = "{}_{}_sys".format(base.get_child(src.basename), idx)
+        result += [str(dest)[rootlen:]]
+        if system_includes[key] != "":
+            dest = "{}/{}".format(dest, system_includes[key])
+        ctx.symlink(src.realpath, dest)
+
     return result
 
 def _lib_dirs(ctx, pkg_config, pkg_name):
@@ -275,6 +288,7 @@ pkg_config = repository_rule(
         "copts": attr.string_list(doc = "Extra copts value."),
         "ignore_opts": attr.string_list(doc = "Ignore listed opts in copts or linkopts."),
         "dynamic": attr.bool(doc = "Use dynamic linking."),
+        "system_includes": attr.string_dict(doc = "Addidional include directories (some pkg-config don't publish this directories). Value is used as destination path."),
         "ignore_includes": attr.string_list(doc = "Include directories exclude list."),
     },
     local = True,

--- a/pkg_config.bzl
+++ b/pkg_config.bzl
@@ -99,12 +99,15 @@ def _ignore_opts(opts, ignore_opts):
     return remain
 
 def _symlinks(ctx, basename, srcpaths):
+    ignore_includes = ctx.attr.ignore_includes
     result = []
     root = ctx.path("")
     base = root.get_child(basename)
     rootlen = len(str(base)) - len(basename)
     for idx, src in enumerate([ctx.path(p) for p in srcpaths]):
         if not src.exists:
+            continue
+        if str(src) in ignore_includes:
             continue
         dest = "{}_{}".format(base.get_child(src.basename), idx)
         ctx.symlink(src.realpath, dest)
@@ -272,7 +275,7 @@ pkg_config = repository_rule(
         "copts": attr.string_list(doc = "Extra copts value."),
         "ignore_opts": attr.string_list(doc = "Ignore listed opts in copts or linkopts."),
         "dynamic": attr.bool(doc = "Use dynamic linking."),
-        "system_includes": attr.string(doc = "Addidional include directories in system /usr/include directory (some pkg-config don't publish this directories)"),
+        "ignore_includes": attr.string_list(doc = "Include directories exclude list."),
     },
     local = True,
     implementation = _pkg_config_impl,


### PR DESCRIPTION
This options need to allow use `vips` on host system with bazel build farm compilation.

For example:
```diff
 pkg_config(
     name = "vips",
     dynamic = True,
+    ignore_includes = [
+        "/usr/include/x86_64-linux-gnu",
+    ],
+    system_includes = {
+        "/usr/include/vips": "vips",
+    }
 )
```